### PR TITLE
9001 bug: fixes unresolved import for consuming applications

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@wellcometrust/design-system",
   "version": "0.2.1",
   "description": "Design system for Wellcome Trust digital products",
+  "main": "dist/index.js",
   "module": "dist/index.js",
   "style": "dist/core.css",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
# Context

See wellcometrust/corporate/issues/9001.

# Description

This PR adds a 'main' property to package.json.

I found the solution from this [Stack Overflow thread](https://stackoverflow.com/questions/42708484/what-is-the-module-package-json-field-for) and the [Rollup docs](https://rollupjs.org/guide/en/#publishing-es-modules).