### PR TITLE
8933 bug(style): removes disabled text color from Button with "link" variant

### DIFF
--- a/src/styles/20-tools/_mixins/_link.scss
+++ b/src/styles/20-tools/_mixins/_link.scss
@@ -16,8 +16,7 @@
     outline-offset: calc(0.5 * var(--space-unit));
   }
 
-  [disabled],
-  &:not([href]) {
+  [disabled] {
     color: var(--color-link-disabled);
   }
 }


### PR DESCRIPTION
See wellcometrust/corporate/issues/8933.

# Context

Rendering a `<Button variant="link" />` component displays like the below (grey text, grey icon - matches the "disabled" style). To align with designs, the colour of both text and icon should be the default link colour.

# Description

This PR removes the selector which applies the above style (inside `@mixin link-base`). It doesn't seem to break anything...