### PR TITLE
9844 task: Update spacing variables

### DIFF
--- a/src/stories/Spacing.stories.mdx
+++ b/src/stories/Spacing.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs';
 
-import { SpacingBlocks } from './Spacing.stories'
+import { ResponsiveSpacingBlocks, StaticSpacingBlocks } from './Spacing.stories'
 
 <Meta title={`Global/Spacing`} />
 
@@ -11,18 +11,19 @@ Spacing metrics are used to ensure that individual elements on a page and across
 Pixels should only be specified as the unit in instances where a dimension doesn't alter, for example borders and keylines.
 
 
+## Static spacing
+
+The default space unit or `--space-unit` is 0.5rem (equivalent to 8 pixels at 100% zoom) and this is the basis for all of the spacing metrics described on this page.
+
+<StaticSpacingBlocks />
+
+
 ## Responsive spacing units
 
 We provide spacing rules for large, medium and small screen sizes and these should be used to build consistency for typography and spacing between sections, headings and text blocks across responsive sites.
 
-<SpacingBlocks />
+<ResponsiveSpacingBlocks />
 
-
-## Static spacing
-
-The default space unit or `--space-unit` is 0.5rem (equivalent to 8 pixels at 100% zoom) and this is the basis for each of the responsive spacing metrics above.
-
-Static spacings which remain consistent across breakpoints are currently in development.
 
 ```
 

--- a/src/stories/Spacing.stories.tsx
+++ b/src/stories/Spacing.stories.tsx
@@ -20,34 +20,134 @@ type SizeProps = {
  * @see {@link https://github.com/wellcometrust/corporate/issues/8709}
  */
 
-export const SpacingBlocks = () => {
+const TokenTableRows = ({ sizes }: { sizes: SizeProps }) => (
+  <>
+    {Object.entries(sizes).map(([key, value]) => {
+      const size = `--${kebabCase(key)}`;
+      const { color, mqBase, mqSmall, mqMedium } = value;
+
+      return (
+        <tr key={size}>
+          <td>{key}</td>
+          <td className="sb-variable">{size}</td>
+          <td>
+            <figure>
+              <div
+                className="sb-space"
+                style={{
+                  backgroundColor: `var(${color})`,
+                  height: `var(${size})`,
+                  width: `var(${size})`
+                }}
+              />
+              <figcaption className="u-visually-hidden">
+                Coloured square indicating the size of {size}
+              </figcaption>
+            </figure>
+          </td>
+          {mqBase && <td>{mqBase} pixels</td>}
+          {mqSmall && <td>{mqSmall} pixels</td>}
+          {mqMedium && <td>{mqMedium} pixels</td>}
+        </tr>
+      );
+    })}
+  </>
+);
+
+export const StaticSpacingBlocks = () => {
   const sizes: SizeProps = {
-    SpaceXl: {
-      color: '--color-green-50',
+    SpaceStaticXxxl: {
+      color: '--color-amber-60',
+      mqBase: '64'
+    },
+    SpaceStaticXxl: {
+      color: '--color-grey-60',
+      mqBase: '48'
+    },
+    SpaceStaticXl: {
+      color: '--color-cyan-60',
+      mqBase: '32'
+    },
+    SpaceStaticLg: {
+      color: '--color-green-60',
+      mqBase: '24'
+    },
+    SpaceStaticMd: {
+      color: '--color-blue-60',
+      mqBase: '16'
+    },
+    SpaceStaticSm: {
+      color: '--color-orange-60',
+      mqBase: '12'
+    },
+    SpaceStaticXs: {
+      color: '--color-red-60',
+      mqBase: '8'
+    },
+    SpaceStaticXxs: {
+      color: '--color-yellow-60',
+      mqBase: '4'
+    }
+  };
+
+  return (
+    <table>
+      <caption>Static spacing units</caption>
+      <thead>
+        <tr>
+          <th scope="col">Token</th>
+          <th scope="col">CSS variable</th>
+          <th scope="col">Preview</th>
+          <th scope="col">Size</th>
+        </tr>
+      </thead>
+      <tbody>
+        <TokenTableRows sizes={sizes} />
+      </tbody>
+    </table>
+  );
+};
+
+export const ResponsiveSpacingBlocks = () => {
+  const sizes: SizeProps = {
+    SpaceResponsiveXxl: {
+      color: '--color-grey-60',
+      mqBase: '48',
+      mqSmall: '72',
+      mqMedium: '96'
+    },
+    SpaceResponsiveXl: {
+      color: '--color-cyan-60',
       mqBase: '32',
       mqSmall: '48',
       mqMedium: '64'
     },
-    SpaceLg: {
-      color: '--color-blue-50',
+    SpaceResponsiveLg: {
+      color: '--color-green-60',
+      mqBase: '24',
+      mqSmall: '32',
+      mqMedium: '48'
+    },
+    SpaceResponsiveMd: {
+      color: '--color-blue-60',
       mqBase: '16',
       mqSmall: '24',
       mqMedium: '32'
     },
-    SpaceMd: {
-      color: '--color-orange-50',
-      mqBase: '8',
-      mqSmall: '12',
+    SpaceResponsiveSm: {
+      color: '--color-orange-60',
+      mqBase: '12',
+      mqSmall: '16',
       mqMedium: '16'
     },
-    SpaceSm: {
-      color: '--color-red-50',
-      mqBase: '6',
+    SpaceResponsiveXs: {
+      color: '--color-red-60',
+      mqBase: '8',
       mqSmall: '8',
       mqMedium: '8'
     },
-    SpaceXs: {
-      color: '--color-amber-40',
+    SpaceResponsiveXxs: {
+      color: '--color-yellow-60',
       mqBase: '4',
       mqSmall: '4',
       mqMedium: '4'
@@ -56,7 +156,9 @@ export const SpacingBlocks = () => {
 
   return (
     <table>
-      <caption>Standard space units and their sizes across breakpoints</caption>
+      <caption>
+        Responsive spacing units and their sizes across breakpoints
+      </caption>
       <thead>
         <tr>
           <th scope="col">Token</th>
@@ -68,34 +170,7 @@ export const SpacingBlocks = () => {
         </tr>
       </thead>
       <tbody>
-        {Object.entries(sizes).map(([key, value]) => {
-          const size = `--${kebabCase(key)}`;
-
-          return (
-            <tr key={size}>
-              <td>{key}</td>
-              <td className="sb-variable">{size}</td>
-              <td>
-                <figure>
-                  <div
-                    className="sb-space"
-                    style={{
-                      backgroundColor: `var(${value.color})`,
-                      height: `var(${size})`,
-                      width: `var(${size})`
-                    }}
-                  />
-                  <figcaption className="u-visually-hidden">
-                    Coloured square indicating the size of {size}
-                  </figcaption>
-                </figure>
-              </td>
-              <td>{value.mqBase} pixels</td>
-              <td>{value.mqSmall} pixels</td>
-              <td>{value.mqMedium} pixels</td>
-            </tr>
-          );
-        })}
+        <TokenTableRows sizes={sizes} />
       </tbody>
     </table>
   );

--- a/src/styles/10-settings/_spacing.scss
+++ b/src/styles/10-settings/_spacing.scss
@@ -1,52 +1,82 @@
 // ----------------------------------
 // UI Settings
 // Spacing
-// https://zpl.io/bJWJNgW
+// https://www.figma.com/file/6bg5Y3Y4gLXgSdVa8Da8Vy/Wellcome-design-system?node-id=316%3A9
 // ----------------------------------
 // Design System 1.0 Alpha
-// 2021-05-01
+// 2022-04-29
 // ----------------------------------
 
 /**
  * Usage
  *
  * .component {
- *   margin: var(--space-md);
- *   padding: calc(2 * var(--space-unit));
+ *   margin: var(--space-responsive-md);
+ *   padding: var(--space-static-md);
  * }
  */
 
 :root {
   --space-unit: 0.5rem;
 
-  // --space-xs: 4px
-  // --space-sm: 6px
-  // --space-md: 8px
-  // --space-lg: 16px
-  // --space-xl: 32px
-  --space-xs: calc(0.5 * var(--space-unit));
-  --space-sm: calc(0.75 * var(--space-unit));
-  --space-md: var(--space-unit);
-  --space-lg: calc(2 * var(--space-unit));
-  --space-xl: calc(4 * var(--space-unit));
+  // | Token           | CSS variable        | Size |
+  // | ----------------| ------------------- | ---- |
+  // | SpaceStaticXxxl | --space-static-xxxl |   64 |
+  // | SpaceStaticXxl  | --space-static-xxl  |   48 |
+  // | SpaceStaticXl   | --space-static-xl   |   32 |
+  // | SpaceStaticLg   | --space-static-lg   |   24 |
+  // | SpaceStaticMd   | --space-static-md   |   16 |
+  // | SpaceStaticSm   | --space-static-sm   |   12 |
+  // | SpaceStaticXs   | --space-static-xs   |    8 |
+  // | SpaceStaticXxs  | --space-static-xxs  |    4 |
+  --space-static-xxxl: calc(8 * var(--space-unit));
+  --space-static-xxl: calc(6 * var(--space-unit));
+  --space-static-xl: calc(4 * var(--space-unit));
+  --space-static-lg: calc(3 * var(--space-unit));
+  --space-static-md: calc(2 * var(--space-unit));
+  --space-static-sm: calc(1.5 * var(--space-unit));
+  --space-static-xs: var(--space-unit);
+  --space-static-xxs: calc(0.5 * var(--space-unit));
 
-  // --space-sm: 8px
-  // --space-md: 12px
-  // --space-lg: 24px
-  // --space-xl: 48px
+  // | Token              | CSS variable           |   Base | Medium |  Large |
+  // | ------------------ | ---------------------- | ------ | ------ | ------ |
+  // | SpaceResponsiveXxl | --space-responsive-xxl |     48 |     72 |     96 |
+  // | SpaceResponsiveXl  | --space-responsive-xl  |     32 |     48 |     64 |
+  // | SpaceResponsiveLg  | --space-responsive-lg  |     24 |     32 |     48 |
+  // | SpaceResponsiveMd  | --space-responsive-md  |     16 |     24 |     32 |
+  // | SpaceResponsiveSm  | --space-responsive-sm  |     12 |     16 |     16 |
+  // | SpaceResponsiveXs  | --space-responsive-xs  |      8 |      8 |      8 |
+  // | SpaceResponsiveXxs | --space-responsive-xxs |      4 |      4 |      4 |
+  --space-responsive-xxl: var(--space-static-xxl);
+  --space-responsive-xl: var(--space-static-xl);
+  --space-responsive-lg: var(--space-static-lg);
+  --space-responsive-md: var(--space-static-md);
+  --space-responsive-sm: var(--space-static-sm);
+  --space-responsive-xs: var(--space-unit);
+  --space-responsive-xxs: var(--space-static-xxs);
+
+
+  // DEPRECATED SPACE VALUES
+  // New "Lg" set of values introduced for --space-responsive variables,
+  // hence --space-lg equates to --space-responsive-md and not --space-responsive-lg
+  --space-xl: var(--space-responsive-xl);
+  --space-lg: var(--space-responsive-md);
+  --space-md: var(--space-responsive-sm);
+  --space-sm: var(--space-unit);
+  --space-xs: var(--space-static-xxs);
+
   @include mq(sm) {
-    --space-sm: var(--space-unit);
-    --space-md: calc(1.5 * var(--space-unit));
-    --space-lg: calc(3 * var(--space-unit));
-    --space-xl: calc(6 * var(--space-unit));
+    --space-responsive-xxl: calc(9 * var(--space-unit));
+    --space-responsive-xl: var(--space-static-xxl);
+    --space-responsive-lg: var(--space-static-xl);
+    --space-responsive-md: var(--space-static-lg);
+    --space-responsive-sm: var(--space-static-md);
   }
 
-  // --space-md: 16px
-  // --space-lg: 32px
-  // --space-xl: 64px
   @include mq(md) {
-    --space-md: calc(2 * var(--space-unit));
-    --space-lg: calc(4 * var(--space-unit));
-    --space-xl: calc(8 * var(--space-unit));
+    --space-responsive-xxl: calc(12 * var(--space-unit));
+    --space-responsive-xl: var(--space-static-xxxl);
+    --space-responsive-lg: var(--space-static-xxl);
+    --space-responsive-md: var(--space-static-xl);
   }
 }

--- a/src/styles/10-settings/_spacing.scss
+++ b/src/styles/10-settings/_spacing.scss
@@ -57,9 +57,10 @@
 
 
   // DEPRECATED SPACE VALUES
-  // New "Lg" set of values introduced for --space-responsive variables,
-  // hence --space-lg equates to --space-responsive-md and not --space-responsive-lg
   --space-xl: var(--space-responsive-xl);
+
+  // A new responsive "Lg" token has been introduced, hence --space-lg
+  // equates to --space-responsive-md and NOT --space-responsive-lg
   --space-lg: var(--space-responsive-md);
   --space-md: var(--space-responsive-sm);
   --space-sm: var(--space-unit);


### PR DESCRIPTION
Relates to wellcometrust/corporate#9844

* New static variables added
* Responsive variables refactored based on Notion page [Spacing changes 04/22](https://www.notion.so/wellcometrust/Spacing-changes-04-22-32548c92d15b49eabe6964c83720e7be)
* Pointed old spacing variables to equivalent new ones
* Storybook updated (screenshots below)

![Screenshot 2022-04-29 at 15 31 37](https://user-images.githubusercontent.com/49439125/165968749-72b949b3-4122-4f87-a4fc-9aeb52efe7c4.png)

![Screenshot 2022-04-29 at 15 32 02](https://user-images.githubusercontent.com/49439125/165968779-7340b28e-6cac-4e1e-872d-96dd5e687868.png)

## Not in this PR
Rollout of new variables across design system components and styles. This will be handled in a subsequent PR.