### PR TITLE
10335 bug: correct typography sizes

### DIFF
--- a/.storybook/styles/_storybook-spacing.scss
+++ b/.storybook/styles/_storybook-spacing.scss
@@ -1,5 +1,5 @@
 .sb-space {
   margin-bottom: var(--space-md);
   opacity: 0.5;
-  transition: all 0.4s ease;
+  transition: all 1s ease;
 }

--- a/src/stories/Typography.stories.tsx
+++ b/src/stories/Typography.stories.tsx
@@ -165,7 +165,9 @@ export const TypographySizes = ({
           <tr key={size}>
             <td>{key}</td>
             <td className="sb-variable">{size}</td>
-            <td style={{ fontSize: `var(${size})` }}>{comment}</td>
+            <td style={{ fontSize: `var(${size})`, transition: 'all ease 1s' }}>
+              {comment}
+            </td>
             {Object.entries(rest).map(([sizeKey, sizeValue]) => (
               <td key={sizeKey}>{sizeValue} pixels</td>
             ))}

--- a/src/styles/10-settings/_typography.scss
+++ b/src/styles/10-settings/_typography.scss
@@ -47,14 +47,17 @@
   --line-height-body: 1.6;
   --line-height-heading: var(--line-height-body);
 
+  // values for medium viewports from 768px and above
   @include mq(sm) {
     --font-size-heading-xxl: calc(34 / 16 * var(--font-size-base));
+    --font-size-heading-xl: calc(28 / 16 * var(--font-size-base));
+  }
+
+  // values for large viewports 1024px wide and above
+  @include mq(md) {
+    --font-size-heading-xxl: calc(40 / 16 * var(--font-size-base));
     --font-size-heading-xl: calc(32 / 16 * var(--font-size-base));
     --font-size-heading-lg: calc(24 / 16 * var(--font-size-base));
     --font-size-heading-md: calc(20 / 16 * var(--font-size-base));
-  }
-
-  @include mq(md) {
-    --font-size-heading-xxl: calc(40 / 16 * var(--font-size-base));
   }
 }

--- a/src/styles/10-settings/_typography.scss
+++ b/src/styles/10-settings/_typography.scss
@@ -21,19 +21,19 @@
   --font-size-base-px: 16; // required for sass calculations
 
   // font size - non-responsive body text
-  --font-size-body-xl: calc(24/16 * var(--font-size-base));
-  --font-size-body-lg: calc(20/16 * var(--font-size-base));
+  --font-size-body-xl: calc(24 / 16 * var(--font-size-base));
+  --font-size-body-lg: calc(20 / 16 * var(--font-size-base));
   --font-size-body-md: var(--font-size-base);
-  --font-size-body-sm: calc(14/16 * var(--font-size-base));
-  --font-size-body-xs: calc(12/16 * var(--font-size-base));
+  --font-size-body-sm: calc(14 / 16 * var(--font-size-base));
+  --font-size-body-xs: calc(12 / 16 * var(--font-size-base));
 
   // font size responsive headings
-  --font-size-heading-xxl: calc(32/16 * var(--font-size-base));
-  --font-size-heading-xl: calc(24/16 * var(--font-size-base));
-  --font-size-heading-lg: calc(22/16 * var(--font-size-base));
-  --font-size-heading-md: calc(18/16 * var(--font-size-base));
+  --font-size-heading-xxl: calc(32 / 16 * var(--font-size-base));
+  --font-size-heading-xl: calc(24 / 16 * var(--font-size-base));
+  --font-size-heading-lg: calc(22 / 16 * var(--font-size-base));
+  --font-size-heading-md: calc(18 / 16 * var(--font-size-base));
   --font-size-heading-sm: var(--font-size-base);
-  --font-size-heading-xs: calc(14/16 * var(--font-size-base));
+  --font-size-heading-xs: calc(14 / 16 * var(--font-size-base));
 
   // font weight
   --font-weight-heading: 500;
@@ -48,12 +48,13 @@
   --line-height-heading: var(--line-height-body);
 
   @include mq(sm) {
-    --font-size-heading-xl: calc(32/16 * var(--font-size-base));
-    --font-size-heading-lg: calc(24/16 * var(--font-size-base));
-    --font-size-heading-md: calc(20/16 * var(--font-size-base));
+    --font-size-heading-xxl: calc(34 / 16 * var(--font-size-base));
+    --font-size-heading-xl: calc(32 / 16 * var(--font-size-base));
+    --font-size-heading-lg: calc(24 / 16 * var(--font-size-base));
+    --font-size-heading-md: calc(20 / 16 * var(--font-size-base));
   }
 
   @include mq(md) {
-    --font-size-heading-xxl: calc(40/16 * var(--font-size-base));
+    --font-size-heading-xxl: calc(40 / 16 * var(--font-size-base));
   }
 }


### PR DESCRIPTION
Relates to wellcometrust/corporate#10335

This PR fixes incorrect font sizes specified for some of the responsive headings to bring them inline with Sketch and Figma.

## To test
1. Download this branch and run `npm i` if necessary
2. Run storybook locally `npm run storybook`
3. Go to http://localhost:6006/?path=/story/global-typography--page#responsive-heading-sizes
4. Change the viewport width and inspect the headings as they change size across the breakpoints (width 768px and 1024px)
5. Compare the font sizes with those in the [Design System typography Sketch file](https://www.sketch.com/s/024ffb6c-3319-42a5-ad52-8389d978a474/a/m1rYrwz#Inspect)
6. Compare the font sizes with those documented in the storybook page