### PR TITLE
10800 task: uses correct focus ring colour css variable

### DIFF
--- a/src/components/Button/button.scss
+++ b/src/components/Button/button.scss
@@ -48,7 +48,7 @@
   transition-property: background-color;
 
   &:focus {
-    outline-color: var(--link-color-focus-outline);
+    outline-color: var(--color-link-focus-outline);
     outline-offset: calc(0.5 * var(--space-unit));
   }
 }

--- a/src/styles/20-tools/_mixins/_typography.scss
+++ b/src/styles/20-tools/_mixins/_typography.scss
@@ -22,7 +22,7 @@
 
   &:focus {
     color: var(--link-color-active);
-    outline-color: var(--link-color-focus-outline);
+    outline-color: var(--color-link-focus-outline);
     outline-offset: calc(0.5 * var(--space-unit));
   }
 
@@ -64,7 +64,7 @@
   }
 
   &:focus {
-    outline-color: var(--link-color-focus-outline);
+    outline-color: var(--color-link-focus-outline);
   }
 
   [disabled],


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/10800

Black focus ring was introduced by accident by using css variable that doesn't exist in the design system.

### This PR

- updates focus colour ring css variable to [--color-link-focus-outline](https://github.com/wellcometrust/design-system/blob/3035aa8fd0bda7e0162a977dc8509453ed6958d0/src/styles/15-theme/_colors.scss#L16), which is `var(--color-blue-50)`
