### PR TITLE
10899 bug: adds interpolation for grid-max-width value

### DIFF
--- a/src/styles/10-settings/_grid.scss
+++ b/src/styles/10-settings/_grid.scss
@@ -18,7 +18,7 @@
   --grid-columns: 6;
   --grid-gutter: calc(1.5 * var(--space-unit)); // 12px
   --grid-margin: 5%;
-  --grid-max-width: rem(1344);
+  --grid-max-width: #{rem(1344)};
 
   @include mq(sm) {
     --grid-gutter: calc(2.5 * var(--space-unit)); // 20px


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/10899

### Context

The design system variable for grid max width is not working in the corporate react.

> To provide maximum compatibility with plain CSS, more recent versions of Sass require SassScript expressions in custom property values to be written within [interpolation](https://sass-lang.com/documentation/interpolation).

Source: [Breaking Change: CSS Variable Syntax](https://sass-lang.com/documentation/breaking-changes/css-vars)
