### PR TITLE
10937 task: fixes slash as division warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "rollup-plugin-terser": "^5.2.0",
         "sass": "^1.29.0",
         "sass-loader": "^8.0.0",
-        "sass-mq": "^5.0.1",
+        "sass-mq": "^6.0.0-beta.1",
         "style-loader": "^1.1.2",
         "stylelint": "^12.0.1",
         "stylelint-config-sass-guidelines": "^6.2.0",
@@ -31978,9 +31978,9 @@
       }
     },
     "node_modules/sass-mq": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/sass-mq/-/sass-mq-5.0.1.tgz",
-      "integrity": "sha512-ugSVZO5fzasSFrGfKCtY02spnkOOfo9U9sXuzCuSXoCl1CgcoqdJRdNmigZkhvRVph1GKM6o0pgI00Jjc445CA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/sass-mq/-/sass-mq-6.0.0.tgz",
+      "integrity": "sha512-h4VicIy8lszFlqqggqLIFGt/9wS5fHLPoTXHRjC8Vw6UsA4s4JtDvEeypXbbECfgY336mXyc/cdpbRacH0UzGA==",
       "dev": true
     },
     "node_modules/sax": {
@@ -61243,9 +61243,9 @@
       }
     },
     "sass-mq": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/sass-mq/-/sass-mq-5.0.1.tgz",
-      "integrity": "sha512-ugSVZO5fzasSFrGfKCtY02spnkOOfo9U9sXuzCuSXoCl1CgcoqdJRdNmigZkhvRVph1GKM6o0pgI00Jjc445CA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/sass-mq/-/sass-mq-6.0.0.tgz",
+      "integrity": "sha512-h4VicIy8lszFlqqggqLIFGt/9wS5fHLPoTXHRjC8Vw6UsA4s4JtDvEeypXbbECfgY336mXyc/cdpbRacH0UzGA==",
       "dev": true
     },
     "sax": {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "rollup-plugin-terser": "^5.2.0",
     "sass": "^1.29.0",
     "sass-loader": "^8.0.0",
-    "sass-mq": "^5.0.1",
+    "sass-mq": "^6.0.0-beta.1",
     "style-loader": "^1.1.2",
     "stylelint": "^12.0.1",
     "stylelint-config-sass-guidelines": "^6.2.0",

--- a/src/styles/20-tools/_functions/_rem.scss
+++ b/src/styles/20-tools/_functions/_rem.scss
@@ -7,6 +7,10 @@
 // 2021-05-01
 // ----------------------------------
 
+@use 'sass:math';
+
+$font-size-base-px: 16;
+
 /**
  * Convert a pixel value to rem units.
  *
@@ -27,7 +31,7 @@
  */
 
 @function rem($size) {
-  $rems: calc(#{$size}rem / var(--font-size-base-px));
+  $rems: math.div($size, $font-size-base-px) * 1rem;
 
-  @return #{$rems};
+  @return $rems;
 }


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/10354 and https://github.com/wellcometrust/corporate/issues/10937 

### This PR

- fixes below warning

![Using / for division is deprecated and will be removed in Dart Sass 2.0.0.](https://user-images.githubusercontent.com/10700103/219622016-efae7836-3c5f-451a-abf6-8831037698bc.png)
