### PR TITLE
10330 task: Allow React 18 as peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -92,8 +92,8 @@
         "npm": ">=7.0.3"
       },
       "peerDependencies": {
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2"
+        "react": "^17.0.2  || ^18.2.0",
+        "react-dom": "^17.0.2 || ^18.2.0"
       }
     },
     "node_modules/@babel/cli": {

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
   "license": "MIT",
   "homepage": "https://github.com/wellcometrust/design-system#readme",
   "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^17.0.2  || ^18.2.0",
+    "react-dom": "^17.0.2 || ^18.2.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.4",


### PR DESCRIPTION
Relates https://github.com/wellcometrust/corporate/issues/10330

Allows us to potentially use React 18 in the Funding Platform