### PR TITLE
Released version 0.4.12: Allows React 18 as peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wellcometrust/design-system",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wellcometrust/design-system",
-      "version": "0.4.11",
+      "version": "0.4.12",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wellcometrust/design-system",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "Design system for Wellcome Trust digital products",
   "module": "dist/index.js",
   "style": "dist/core.css",


### PR DESCRIPTION
Bumps version to 0.4.12